### PR TITLE
test: adiciona testes do comando !café

### DIFF
--- a/modules/commands/_cafe.spec.js
+++ b/modules/commands/_cafe.spec.js
@@ -1,0 +1,22 @@
+const levelup = require('levelup');
+const memdown = require('memdown');
+
+const cafe = require('./_cafe');
+
+describe('cafe command', () => {
+  it('has the right trigger', () => {
+    expect(cafe.trigger.test('acafé')).toBe(false);
+    expect(cafe.trigger.test('caféé')).toBe(false);
+    expect(cafe.trigger.test('')).toBe(false);
+    expect(cafe.trigger.test('pinga')).toBe(false);
+    expect(cafe.trigger.test('café')).toBe(true);
+    expect(cafe.trigger.test('cafe')).toBe(true);
+  });
+
+  it('returns the right message', async () => {
+    const db = levelup(memdown());
+
+    expect(await cafe.run({ db })).toBe('Jeans já tomou 1 café');
+    expect(await cafe.run({ db })).toBe('Jeans já tomou 2 cafés');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,16 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3907,6 +3917,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3937,6 +3953,19 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memdown": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
+      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "^7.2.0",
+        "buffer": "^6.0.3",
+        "functional-red-black-tree": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ltgt": "^2.2.0"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-import": "^2.25.3",
     "husky": "^7.0.4",
     "jest": "^27.4.7",
+    "memdown": "^6.1.1",
     "nodemon": "^2.0.15"
   }
 }


### PR DESCRIPTION
Para criar esses testes foi necessário a utilização do memdown, que é a implementação em memória do leveldown.

Esse PR resolve a issue: https://github.com/jlcarvalho/bot-da-live/issues/5