### PR TITLE
ci: ajusta configuração do github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 name: CI
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      
+
       - uses: actions/setup-node@v1
         with:
           node-version: 12.14


### PR DESCRIPTION
O evento `pull_request` executa o workflow quando o PR
é aberto ou quando o head do branch do PR é alterado.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request