### PR TITLE
fix: resolve notificações duplicadas quando há mais de um cliente

### DIFF
--- a/modules/alerts/index.js
+++ b/modules/alerts/index.js
@@ -17,12 +17,12 @@ const Alerts = ({ client, app, io }) => {
 
   client.on('cheer', (channel, user) => {
     client.say(channel, `Obrigado pelos ${user.bits} bits ${user['display-name']}!!!`);
-    io.emit('resub', { username: user['display-name'], bits: user.bits });
+    io.emit('cheer', { username: user['display-name'], bits: user.bits });
   });
 
   client.on('raided', (channel, username) => {
     client.say(channel, `Obrigado pela raid ${username}, sejam todos bem vindos!`);
-    io.emit('resub', { username });
+    io.emit('raided', { username });
   });
 };
 

--- a/modules/alerts/index.js
+++ b/modules/alerts/index.js
@@ -5,26 +5,24 @@ const Alerts = ({ client, app, io }) => {
     res.sendFile(path.join(__dirname, '../../assets/alerts.html'));
   });
 
-  io.on('connection', (socket) => {
-    client.on('subscription', (channel, username) => {
-      client.say(channel, `Obrigado pelo sub ${username}!!!`);
-      socket.emit('subscription', { username });
-    });
+  client.on('subscription', (channel, username) => {
+    client.say(channel, `Obrigado pelo sub ${username}!!!`);
+    io.emit('subscription', { username });
+  });
 
-    client.on('resub', (channel, username, months) => {
-      client.say(channel, `Obrigado pelo resub de ${months} meses ${username}!!!`);
-      socket.emit('resub', { username, months });
-    });
+  client.on('resub', (channel, username, months) => {
+    client.say(channel, `Obrigado pelo resub de ${months} meses ${username}!!!`);
+    io.emit('resub', { username, months });
+  });
 
-    client.on('cheer', (channel, user) => {
-      client.say(channel, `Obrigado pelos ${user.bits} bits ${user['display-name']}!!!`);
-      socket.emit('resub', { username: user['display-name'], bits: user.bits });
-    });
+  client.on('cheer', (channel, user) => {
+    client.say(channel, `Obrigado pelos ${user.bits} bits ${user['display-name']}!!!`);
+    io.emit('resub', { username: user['display-name'], bits: user.bits });
+  });
 
-    client.on('raided', (channel, username) => {
-      client.say(channel, `Obrigado pela raid ${username}, sejam todos bem vindos!`);
-      socket.emit('resub', { username });
-    });
+  client.on('raided', (channel, username) => {
+    client.say(channel, `Obrigado pela raid ${username}, sejam todos bem vindos!`);
+    io.emit('resub', { username });
   });
 };
 


### PR DESCRIPTION
Acredito que a maneira mais fácil de resolver esse problema
é fazer broadcast para todos os clientes conectados ao socket
em vez de emitir de maneira individual. Como o bot não reage
aos eventos de connect e disconnect, não teria prejuízo.

https://socket.io/docs/v4/broadcasting-events
https://socket.io/docs/v4/server-api/#namespaceemiteventname-args

Closes #4